### PR TITLE
V0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM java:7-jre-alpine
+FROM openjdk:8-jre-slim
 
 MAINTAINER komuW <komuw05@gmail.com>
 
-RUN apk add --update bash && rm -rf /var/cache/apk/*
+RUN apt -y autoremove && \
+    apt -y clean && \
+    rm -rf ~/.cache/* && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/ && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY SMPPSim /app
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ docker image for SMPP simulator from http://www.seleniumsoftware.com/
 
 
 # usage           
+1. build:
+```sh
+docker build -t komuw/smpp_server:<tag> .
+```
 
-docker run -it -P komuw/smpp_server:v0.2                              
+2. run:
+```sh
+docker run -it -P komuw/smpp_server     
+```
                           
 
 

--- a/SMPPSim/conf/smppsim.props
+++ b/SMPPSim/conf/smppsim.props
@@ -54,7 +54,7 @@ PERCENTAGE_REJECTED=2
 # Time messages held in queue before being discarded, after a final state has been reached (milliseconds)
 # For example, after transitioning to DELIVERED (a final state), state info about this message will be
 # retained in the queue for a further (e.g.) 60000 milliseconds before being deleted.
-DISCARD_FROM_QUEUE_AFTER=60000
+DISCARD_FROM_QUEUE_AFTER=5000
 
 # Web Management
 HTTP_PORT=8884
@@ -84,8 +84,8 @@ ESME_TO_ESME=false
 
 # QUEUES
 # Maximum size parameters are expressed as max number of objects the queue can hold
-OUTBOUND_QUEUE_MAX_SIZE=1000
-INBOUND_QUEUE_MAX_SIZE=1000
+OUTBOUND_QUEUE_MAX_SIZE=250000
+INBOUND_QUEUE_MAX_SIZE=250000
 
 # The delayed inbound queue holds DELIVER_SM (MO) messages which could not be delivered to the selected ESME
 # because it replied "queue full". Such messages get stored in the delayed inbound queue and delivery is attempted again


### PR DESCRIPTION
What:
- upgrade java version
- increase queue sizes from 1,000 to 250,000 messages
- decrease time taken in queue from 60 to 5 seconds
- released a new docker image tagged; `komuw/smpp_server:v0.3`

Why:
- when running benchmarks, with the low queue size, the smpp client would get a lot of `ESME_RMSGQFUL` (`Message Queue Full`)[1]

Ref:
1. https://github.com/komuw/naz/issues/103#issuecomment-497948169
